### PR TITLE
記録した際のTTL更新をmessageにも対応

### DIFF
--- a/inv_aki_flask/model/datastore_client.py
+++ b/inv_aki_flask/model/datastore_client.py
@@ -124,6 +124,10 @@ class DataStoreClient:
             expiration=expiration,
         )
 
+    def update_message_expiration(self, message, expire_at):
+        expiration = datetime.now() + timedelta(days=expire_at)
+        self._update(message, expiration=expiration)
+
     def get_session(self, sessionid):
         return self._select(
             kind=DataStoreClient.KIND_SESSION,

--- a/inv_aki_flask/views/result.py
+++ b/inv_aki_flask/views/result.py
@@ -23,5 +23,12 @@ def post():
             judge=False,  # 閲覧ページから再登録できないように
             expire_at=7,  # 記録したデータは7日間有効(FIXME 要調整)
         )
+        messages = datastore_client.get_messages(sessionid=sessionid)
+        for message in messages:
+            # FIXME 内部メソッド直接使ってるの微妙なのでリファクタする
+            datastore_client.update_message_expiration(
+                message,
+                expire_at=7,  # 記録したデータは7日間有効(FIXME 要調整)
+            )
 
     return redirect(url_for("ranking.show"))

--- a/inv_aki_flask/views/result.py
+++ b/inv_aki_flask/views/result.py
@@ -25,7 +25,6 @@ def post():
         )
         messages = datastore_client.get_messages(sessionid=sessionid)
         for message in messages:
-            # FIXME 内部メソッド直接使ってるの微妙なのでリファクタする
             datastore_client.update_message_expiration(
                 message,
                 expire_at=7,  # 記録したデータは7日間有効(FIXME 要調整)


### PR DESCRIPTION
- 正解したセッションを記録する時，Sessionエンティティのexpirationを長く更新していたが，Messageエンティティのexpirationを更新し忘れていたので修正